### PR TITLE
adds days_stagnant

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
   'contents_url',
   'contributors_url',
   'created_at',
+  'days_stagnant',
   'default_branch',
   'deployments_url',
   'description',

--- a/index.js
+++ b/index.js
@@ -41,6 +41,19 @@ module.exports = function(user, token, keys, callback) {
                         }
                     },
                     function(callback) {
+                        if (keys.indexOf('days_stagnant') > -1) {
+                            ghrepo.commits(function(err, commits) {
+                                var last = new Date(commits[0].commit.author.date);
+                                var today = new Date();
+                                var diff = Math.abs(last - today);
+                                repo.days_stagnant = Math.round(diff / (1000 * 60 * 60 * 24)) + ' days';
+                                callback();
+                            });
+                        } else {
+                            callback();
+                        }
+                    },
+                    function(callback) {
                         if (keys.indexOf('commits') > -1) {
                             ghrepo.contributors(function(err, contributors) {
                                 repo.commits = contributors.map(function(a) {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function(user, token, keys, callback) {
                                 var last = new Date(commits[0].commit.author.date);
                                 var today = new Date();
                                 var diff = Math.abs(last - today);
-                                repo.days_stagnant = Math.round(diff / (1000 * 60 * 60 * 24)) + ' days';
+                                repo.days_stagnant = Math.round(diff / (1000 * 60 * 60 * 24));
                                 callback();
                             });
                         } else {


### PR DESCRIPTION
`github-metrics --user gabrielcsapo --keys 'full_name, homepage, commits, days_stagnant' --sort 'days_stagnant'`

| commits | days_stagnant | full_name | homepage |
| --- | --- | --- | --- |
| 9 | 412 | "gabrielcsapo/tabular" |  |
| 16 | 404 | "gabrielcsapo/prompt" |  |
| 11 | 309 | "gabrielcsapo/dobby" |  |
| 22 | 45 | "gabrielcsapo/steno" | "http://gabrielcsapo.github.io/steno/" |
| 5 | 40 | "gabrielcsapo/granary-sample" |  |
| 55 | 39 | "gabrielcsapo/granary" | "http://gabrielcsapo.github.io/granary-server/" |
| 146 | 35 | "gabrielcsapo/granary-server" | "http://granaryjs.com" |
| 49 | 20 | "gabrielcsapo/saywhat" | "http://gabrielcsapo.github.io/saywhat/" |
| 37 | 11 | "gabrielcsapo/grunt-screenshot" |  |
| 103 | 9 | "gabrielcsapo/node-notebook" | "http://gabrielcsapo.github.io/node-notebook/" |
| 47 | 9 | "gabrielcsapo/gabrielcsapo.com" | "www.gabrielcsapo.com" |
| 61 | 8 | "gabrielcsapo/node-distribute" |  |
| 225 | 5 | "gabrielcsapo/node-flat-db" |  |
| 6 | 5 | "gabrielcsapo/compress-object" |  |
| 102 | 3 | "gabrielcsapo/psychic-ui" | "http://gabrielcsapo.github.io/psychic-ui/" |
| 54 | 3 | "gabrielcsapo/node-chat-rooms" |  |
| 22 | 2 | "gabrielcsapo/npm-what" |  |
| 39 | 2 | "gabrielcsapo/node-dashboard" |  |
| 12 | 0 | "gabrielcsapo/github-metrics" |  |
